### PR TITLE
Increased Customization for Node Runners

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -10,13 +10,26 @@ run () {
 
     read -p 'Directory to Install Node [any valid directory : $HOME]: ' installation_loc # variable of where to install algorand node
     read -p 'Algorand Node Type [mainnet/testnet : mainnet]: ' node_type # type of algorand node to run
-    read -p 'Run Fast Catchup? Read about Fast Catchup Here (https://developer.algorand.org/docs/run-a-node/setup/install/#sync-node-network-using-fast-catchup) [yes/no : yes]: ' fast_catchup
-    read -p 'Automate Fast Catchups [yes/no : yes]: ' automate_catchups
+    read -p 'Run Fast Catchup? Read about Fast Catchup Here (https://developer.algorand.org/docs/run-a-node/setup/install/#sync-node-network-using-fast-catchup) [yes/no : no]: ' fast_catchup # run fast catchup during installation
+    read -p 'Automate Fast Catchups [yes/no : yes]: ' automate_catchups # automate catchups?
 
 
-    if [ -z "$installation_loc" ]; then
+    if [ -z "$installation_loc" ]; then # if $installation_loc is empty or not set
         installation_loc=$HOME
     fi;
+    
+    if [ -z $node_type ]; then # if $node_type is empty or not set
+        node_type='mainnet'
+    fi;
+
+    if [ -z fast_catchup ]; then # if $fast_catchup is empty or not set
+        fast_catchup='no'
+    fi;
+
+    if [ -z automate_catchups ]; then # if $automate_catchups is empty or not set
+        automate_catchups='no'
+    fi;
+
 
     echo "Installing in:" $installation_loc
     change_dir $installation_loc # change to $HOME dir.
@@ -119,9 +132,14 @@ run_node () {
         ./goal node start -d $ALGORAND_DATA
         echo ''
     elif [ $1 == "testnet" ]; then
-        mkdir testnetdata
-        cp genesisfiles/testnet/genesis.json $installation_loc/node/testnetdata
-        ./goal node start -d testnetdata
+        if [ -d "testnetdata" ]; then
+            cp genesisfiles/testnet/genesis.json $installation_loc/node/testnetdata
+            ./goal node start -d testnetdata
+        else 
+            mkdir testnetdata
+            cp genesisfiles/testnet/genesis.json $installation_loc/node/testnetdata
+            ./goal node start -d testnetdata
+        fi;
     else
         echo "$1 is an invalid or currently unsupported Algorand Node Type. Try: mainnet, testnet"
         exit 1;

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -8,31 +8,60 @@ main () {
 
 run () {
 
-    change_dir $HOME # change to $HOME dir.
-    FOLDER=$(pwd)/node
+    read -p 'Directory to Install Node [any valid directory : $HOME]: ' installation_loc # variable of where to install algorand node
+    read -p 'Algorand Node Type [mainnet/testnet : mainnet]: ' node_type # type of algorand node to run
+    read -p 'Run Fast Catchup? Read about Fast Catchup Here (https://developer.algorand.org/docs/run-a-node/setup/install/#sync-node-network-using-fast-catchup) [yes/no : yes]: ' fast_catchup
+    read -p 'Automate Fast Catchups [yes/no : yes]: ' automate_catchups
+
+
+    if [ -z "$installation_loc" ]; then
+        installation_loc=$HOME
+    fi;
+
+    echo "Installing in:" $installation_loc
+    change_dir $installation_loc # change to $HOME dir.
+    FOLDER=$installation_loc/node
 
     if [ -d "$FOLDER" ]; then
         # if the node dir already exists, do not mkdir. Just cd into it.
-        echo "node directory already exists, skipping..."
-        cd node
+        cd $installation_loc/node
     else
         # if the node dir does not exist, mkdir and then cd into it.
         mk_node_dir
     fi
 
-    # create ALGORAND_DATA env var
-    create_env_var
+    # create ALGORAND_DATA env var in installation dir
+    create_env_var $installation_loc
+
     # install the update.sh script
     install https://raw.githubusercontent.com/algorand/go-algorand-doc/master/downloads/installers/update.sh
 
     # change the permissions of the update.sh file
-    make_executable update.sh
+    make_executable $installation_loc/node/update.sh
     # run the update.sh script
     run_update_script
     # start the node
-    run_node
+
+    run_node $node_type
+
     # check the status of the node
     check_status
+
+    if [ $fast_catchup == 'yes' ]; then
+        # do fast catchup
+        checkpoint=$(wget -qO- https://algorand-catchpoints.s3.us-east-2.amazonaws.com/channel/$node_type/latest.catchpoint | sed -e 's/<[^>]*>//g')
+
+        cd $installation_loc/node
+        ./goal node catchup $checkpoint -d $ALGORAND_DATA
+
+        echo "Running fast catchup... This may take a few minutes."
+    fi;
+
+    if [ $automate_catchups == 'yes' ]; then
+        crontab -l >> $installation_loc/node/catchup_cron_job
+        echo "00 * * * * $installation_loc/node/update.sh -i -c stable -d $ALGORAND_DATA > $installation_loc/node/sync.log 2>&1" >> $installation_loc/node/catchup_cron_job
+        crontab $installation_loc/node/catchup_cron_job
+    fi;
 }
 
 change_dir () {
@@ -52,8 +81,12 @@ create_env_var() {
     # create ALGORAND_DATA env var
     # This tells the Algorand Node where to store data related to our node.
 
-    export ALGORAND_DATA=$(pwd)/data
-    echo $ALGORAND_DATA
+    if [ $node_type == 'mainnet' ]; then
+        export ALGORAND_DATA=$1/node/data
+    elif [ $node_type == 'testnet' ]; then
+        export ALGORAND_DATA=$1/node/testnetdata
+    fi;
+    echo "Algorand Data Directory:" $ALGORAND_DATA
     return 1
 }
 
@@ -66,21 +99,33 @@ install() {
 make_executable() {
     # make the passed file ($1) executable
 
-    chmod +x $1
+    chmod 544 $1
 }
 
 run_update_script() {
     # updates the node to the latest version
     # -n ensures the node does not automatically start
 
-    echo "RUNNING UPDATER:"
-    sh -c "yes | ./update.sh -i -c stable -p ~/node -d ~/node/data -n"
+    echo "RUNNING UPDATE.SH:"
+    sh -c "yes | $installation_loc/node/update.sh -i -c stable -p $installation_loc/node -d $ALGORAND_DATA -n"
+    echo ''
 }
 
 run_node () {
-    # begins running the Algorand node
+    cd $installation_loc/node
     echo "STARTING NODE:"
-    ./goal node start -d $ALGORAND_DATA
+    if [ $1 == "mainnet" ]; then
+        # begins running the Algorand node
+        ./goal node start -d $ALGORAND_DATA
+        echo ''
+    elif [ $1 == "testnet" ]; then
+        mkdir testnetdata
+        cp genesisfiles/testnet/genesis.json $installation_loc/node/testnetdata
+        ./goal node start -d testnetdata
+    else
+        echo "$1 is an invalid or currently unsupported Algorand Node Type. Try: mainnet, testnet"
+        exit 1;
+    fi;
 }
 
 check_status () {
@@ -89,7 +134,9 @@ check_status () {
     # If error, will return "Cannot contact Algorand node..."
 
     echo "CHECKING NODE STATUS:"
+    cd $installation_loc/node
     ./goal node status -d $ALGORAND_DATA
+    echo ''
 }
 
 main

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -11,22 +11,22 @@ run () {
     read -p 'Directory to Install Node [any valid directory : $HOME]: ' installation_loc # variable of where to install algorand node
     read -p 'Algorand Node Type [mainnet/testnet : mainnet]: ' node_type # type of algorand node to run
     read -p 'Run Fast Catchup? Read about Fast Catchup Here (https://developer.algorand.org/docs/run-a-node/setup/install/#sync-node-network-using-fast-catchup) [yes/no : no]: ' fast_catchup # run fast catchup during installation
-    read -p 'Automate Fast Catchups [yes/no : yes]: ' automate_catchups # automate catchups?
+    read -p 'Automate Fast Catchups [yes/no : no]: ' automate_catchups # automate catchups?
 
 
     if [ -z "$installation_loc" ]; then # if $installation_loc is empty or not set
         installation_loc=$HOME
     fi;
     
-    if [ -z $node_type ]; then # if $node_type is empty or not set
+    if [ -z "$node_type" ]; then # if $node_type is empty or not set
         node_type='mainnet'
     fi;
 
-    if [ -z fast_catchup ]; then # if $fast_catchup is empty or not set
+    if [ -z "$fast_catchup" ]; then # if $fast_catchup is empty or not set
         fast_catchup='no'
     fi;
 
-    if [ -z automate_catchups ]; then # if $automate_catchups is empty or not set
+    if [ -z "$automate_catchups" ]; then # if $automate_catchups is empty or not set
         automate_catchups='no'
     fi;
 
@@ -60,8 +60,10 @@ run () {
     # check the status of the node
     check_status
 
-    if [ $fast_catchup == 'yes' ]; then
+    if [[ $fast_catchup == "yes" ]]; then
         # do fast catchup
+        
+        # quietly download last catchpoint, extract the plaintext from the page w/ sed
         checkpoint=$(wget -qO- https://algorand-catchpoints.s3.us-east-2.amazonaws.com/channel/$node_type/latest.catchpoint | sed -e 's/<[^>]*>//g')
 
         cd $installation_loc/node
@@ -70,7 +72,7 @@ run () {
         echo "Running fast catchup... This may take a few minutes."
     fi;
 
-    if [ $automate_catchups == 'yes' ]; then
+    if [[ $automate_catchups == "yes" ]]; then
         crontab -l >> $installation_loc/node/catchup_cron_job
         echo "00 * * * * $installation_loc/node/update.sh -i -c stable -d $ALGORAND_DATA > $installation_loc/node/sync.log 2>&1" >> $installation_loc/node/catchup_cron_job
         crontab $installation_loc/node/catchup_cron_job
@@ -94,9 +96,9 @@ create_env_var() {
     # create ALGORAND_DATA env var
     # This tells the Algorand Node where to store data related to our node.
 
-    if [ $node_type == 'mainnet' ]; then
+    if [ "$node_type" == 'mainnet' ]; then
         export ALGORAND_DATA=$1/node/data
-    elif [ $node_type == 'testnet' ]; then
+    elif [ "$node_type" == 'testnet' ]; then
         export ALGORAND_DATA=$1/node/testnetdata
     fi;
     echo "Algorand Data Directory:" $ALGORAND_DATA
@@ -127,11 +129,11 @@ run_update_script() {
 run_node () {
     cd $installation_loc/node
     echo "STARTING NODE:"
-    if [ $1 == "mainnet" ]; then
+    if [ "$1" == "mainnet" ]; then
         # begins running the Algorand node
         ./goal node start -d $ALGORAND_DATA
         echo ''
-    elif [ $1 == "testnet" ]; then
+    elif [ "$1" == "testnet" ]; then
         if [ -d "testnetdata" ]; then
             cp genesisfiles/testnet/genesis.json $installation_loc/node/testnetdata
             ./goal node start -d testnetdata


### PR DESCRIPTION
These updates allow for greater customization of the node upon initial installation. They can:
1. run a testnet or mainnet node, 
2. choose the installation directory, 
3. state whether or not they want to run fast catchup upon installation, and 
4. state whether or not they want to automate fast catchups. If [yes], I create a CRON job for them.
